### PR TITLE
Update EMT.R

### DIFF
--- a/R/EMT.R
+++ b/R/EMT.R
@@ -72,7 +72,8 @@ function(observed, prob, size, groups, numEvents)
     eventMat <- findVectors(groups,size)    		
     if( nrow(eventMat) != numEvents ) stop("Wrong number of events calculated. \n This is probably a bug.")
 
-    eventProb <- apply(eventMat, 1, function(x) dmultinom(x, size=size, prob=prob))  
+    eventProb <- apply(eventMat, 1, function(x) dmultinom(x, size=size, prob=prob)) 
+    eventProb[abs(eventProb - pObs) < .Machine$double.eps^0.5] <- pObs
     p.value = sum(eventProb[eventProb <= pObs])
 
     if(round(sum(eventProb),digits=2) != 1) stop("Wrong values for probabilities. \n This is probably a bug.")


### PR DESCRIPTION
The additional line 76 in the definition of ExactMultinomialTest is needed to prevent a bug that results in wrong exact p-values in situations where the same point probabilities as the observed point probability results for different constellations of category frequencies, especially when probabilities (prob) do not represent a uniform distribution. In this case the exact same point probabilities in some situations may not be included in the computation of the p-value in line 77 due to double precision floating point imprecision.
Example with 3 categories and n = 3: 
ExactMultinomialTest(observed = c(0, 3, 0), prob = c(0.6, 0.3, 0.1), size = 3, groups = 3, numEvents = 10) results in a p-value of 0.055 since it does not include the point probability of the constellation c(0,2,1) [dmultinom(c(0, 2, 1), prob = c(0.6, 0.3, 0.1))] which is also exactly 0.027 (as is the observed point probability dmultinom(c(0, 3, 0), prob = c(0.6, 0.3, 0.1)). Since the p-value is defined as the sum of all point probabilities <= the observed constellation, the constellation c(0, 2, 1) has to be counted. In the current version of EMT this is not the case since (eventProb <= pObs) in line 77 does not allow for a tolerance due to float imprecision. The added line 76 assigns pObs to those probabilities that are actually the same (only imprecisely computed) before the p-value is computed in the following line 77.
Best regards, Boris Mayer & Dan Studer (University of Bern, Institute of Psychology)